### PR TITLE
fix(ffi): correctly include variant definition for `curwin_col_off`

### DIFF
--- a/lua/pretty-fold/init.lua
+++ b/lua/pretty-fold/init.lua
@@ -9,6 +9,11 @@ ffi.cdef([[
   extern win_T *curwin;
 ]])
 
+---@diagnostic disable-next-line: unused-local, unused-function
+local function curwin_col_off()
+  return ffi.C.win_col_off(ffi.C.curwin)
+end
+
 local M = {
   foldtext = {}, -- Table with all 'foldtext' functions.
   ft_ignore = {}, -- Set with filetypes to be ignored.


### PR DESCRIPTION
I accidentally forgot this part in the first commit, but we do still need a function called `curwin_col_off` even though it was not used directly in `init.lua`.